### PR TITLE
Add maintainer-approved compatibility report bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -20,9 +20,25 @@ body:
   - type: input
     id: version
     attributes:
-      label: SharpEmu version (commit or release)
+      label: SharpEmu build (commit or release, not the game version)
+      description: Use the SharpEmu commit SHA or release shown in the emulator.
+      placeholder: 24b82a7 or v0.1.0
     validations:
       required: true
+  - type: input
+    id: tested_date
+    attributes:
+      label: Test date
+      description: The date you ran this test.
+      placeholder: YYYY-MM-DD
+    validations:
+      required: true
+  - type: input
+    id: game_version
+    attributes:
+      label: Game version
+      description: Optional game update/version, if known.
+      placeholder: '1.004'
   - type: dropdown
     id: os
     attributes:
@@ -41,3 +57,10 @@ body:
       description: Include screenshots if possible. Use dumps of games you own.
     validations:
       required: true
+  - type: checkboxes
+    id: ownership
+    attributes:
+      label: Testing confirmation
+      options:
+        - label: I tested a dump of a game I own.
+          required: true

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -1,0 +1,144 @@
+name: Convert compatibility report
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Open compatibility report issue number
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: compat-report-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  convert:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'compat-approved' &&
+        github.event.issue.pull_request == null
+      )
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.COMPAT_BOT_TOKEN || github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+      BRANCH: compat/issue-${{ github.event.issue.number || inputs.issue_number }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.COMPAT_BOT_TOKEN || github.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Check request and existing PR
+        id: preflight
+        shell: bash
+        run: |
+          if [[ ! "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid issue number: $ISSUE_NUMBER" >&2
+            exit 1
+          fi
+
+          existing_url="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$BRANCH" \
+              --state open \
+              --json url \
+              --jq '.[0].url // empty'
+          )"
+          echo "existing_url=$existing_url" >> "$GITHUB_OUTPUT"
+          if [[ -n "$existing_url" ]]; then
+            echo "A conversion PR already exists: $existing_url"
+          elif [[ -n "$(git ls-remote --heads origin "refs/heads/$BRANCH")" ]]; then
+            echo "::error::Branch $BRANCH already exists without an open pull request. Delete the stale branch or reopen its pull request before retrying."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        if: steps.preflight.outputs.existing_url == ''
+        run: npm ci
+
+      - name: Generate compatibility report
+        if: steps.preflight.outputs.existing_url == ''
+        id: convert
+        run: >-
+          node scripts/issue-to-compat.mjs
+          --issue "$ISSUE_NUMBER"
+          --repo "$GITHUB_REPOSITORY"
+
+      - name: Validate generated report
+        if: steps.preflight.outputs.existing_url == ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          npm test
+          npm run build
+
+      - name: Open report pull request
+        if: steps.preflight.outputs.existing_url == ''
+        shell: bash
+        env:
+          REPORT_PATH: ${{ steps.convert.outputs.report_path }}
+        run: |
+          git config user.name "sharpemu-compat-bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add -- "$REPORT_PATH"
+
+          if git diff --cached --quiet; then
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "The report already matches the published compatibility entry; no PR was needed."
+            exit 0
+          fi
+
+          git commit -m "compat: import report #$ISSUE_NUMBER"
+          git push --set-upstream origin "$BRANCH"
+
+          pr_body="$(
+            printf 'Generated from compatibility report #%s after maintainer approval.\n\nPlease review the inferred metadata and submitted evidence before merging.\n\nCloses #%s' \
+              "$ISSUE_NUMBER" \
+              "$ISSUE_NUMBER"
+          )"
+          pr_url="$(
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH" \
+              --draft \
+              --title "compat: import report #$ISSUE_NUMBER" \
+              --body "$pr_body"
+          )"
+
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "Automated compatibility report PR opened: $pr_url"
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --add-label compat-pr-opened
+
+      - name: Report conversion failure
+        if: failure() && steps.preflight.outputs.existing_url == ''
+        run: >-
+          gh issue comment "$ISSUE_NUMBER"
+          --repo "$GITHUB_REPOSITORY"
+          --body "Automatic conversion failed validation.
+          A maintainer can inspect the
+          [workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."

--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ it to the game's primary entry automatically. The build fails on reports whose
 title ID isn't in the database or whose filename doesn't match the front
 matter.
 
+### Maintainer report conversion
+
+Compatibility issues are intake records; Markdown in `src/content/compat` is
+the published source of truth. Review the submitted build, test date, status,
+ownership confirmation, notes, and evidence. When it is ready, add the
+`compat-approved` label. The `Convert compatibility report` workflow then:
+
+1. Parses and sanitizes the issue form without evaluating issue content.
+2. Validates the title ID against `src/data/games.json`.
+3. Creates a new report or updates the existing regional report for that game.
+4. Runs `npm test` and the full Astro build.
+5. Opens `compat/issue-<number>` as a draft PR with `Closes #<number>`.
+
+The workflow never merges its PR. It can also be run manually from Actions with
+an issue number.
+
+The SharpEmu organization currently prevents the built-in `GITHUB_TOKEN` from
+creating pull requests. To activate conversion, either:
+
+- Have an organization owner enable **Allow GitHub Actions to create and approve
+  pull requests**; or
+- Add a fine-grained token as the `COMPAT_BOT_TOKEN` Actions secret, limited to
+  this repository with read/write access to Contents, Issues, and Pull requests.
+
+The workflow prefers `COMPAT_BOT_TOKEN` when present and otherwise uses
+`GITHUB_TOKEN`, so no workflow change is needed if the organization policy is
+enabled later.
+
 ## Downloads page
 
 `/downloads` renders GitHub releases from `sharpemu/sharpemu` **at build time**

--- a/scripts/issue-to-compat.mjs
+++ b/scripts/issue-to-compat.mjs
@@ -1,0 +1,271 @@
+import { execFileSync } from 'node:child_process';
+import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const STATUSES = new Set(['nothing', 'boots', 'menus', 'ingame', 'playable']);
+const OPERATING_SYSTEMS = new Set(['windows', 'linux', 'macos']);
+const EMPTY_RESPONSES = new Set(['', '_No response_', 'No response']);
+
+export function parseIssueForm(body) {
+  const sections = new Map();
+  let currentLabel = null;
+  let currentLines = [];
+
+  const saveSection = () => {
+    if (!currentLabel) return;
+    sections.set(currentLabel, currentLines.join('\n').trim());
+  };
+
+  for (const line of String(body ?? '').replaceAll('\r\n', '\n').split('\n')) {
+    const heading = /^###\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      saveSection();
+      currentLabel = heading[1];
+      currentLines = [];
+    } else if (currentLabel) {
+      currentLines.push(line);
+    }
+  }
+  saveSection();
+  return sections;
+}
+
+function sectionValue(sections, ...labels) {
+  for (const label of labels) {
+    const value = sections.get(label)?.trim() ?? '';
+    if (!EMPTY_RESPONSES.has(value)) return value;
+  }
+  return '';
+}
+
+function imageAttribute(tag, name) {
+  const expression = new RegExp(`\\b${name}=(?:"([^"]*)"|'([^']*)')`, 'i');
+  const match = expression.exec(tag);
+  return match?.[1] ?? match?.[2] ?? '';
+}
+
+export function sanitizeIssueMarkdown(markdown) {
+  return String(markdown ?? '')
+    .replaceAll('\r\n', '\n')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<img\b[^>]*>/gi, (tag) => {
+      const source = imageAttribute(tag, 'src');
+      const allowed =
+        source.startsWith('https://github.com/user-attachments/') ||
+        source.startsWith('https://user-images.githubusercontent.com/');
+      if (!allowed) return '';
+
+      const alt = imageAttribute(tag, 'alt').replace(/[[\]]/g, '').trim() || 'Test screenshot';
+      return `![${alt}](${source})`;
+    })
+    .replace(/<[^>]+>/g, '')
+    .replace(/\]\(\s*javascript:[^)]+\)/gi, '](#)')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function validDate(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return (
+    !Number.isNaN(date.getTime()) &&
+    date.getUTCFullYear() === Number(match[1]) &&
+    date.getUTCMonth() + 1 === Number(match[2]) &&
+    date.getUTCDate() === Number(match[3])
+  );
+}
+
+export function normalizeReport(issue, games) {
+  const sections = parseIssueForm(issue.body);
+  const warnings = [];
+  const titleId = sectionValue(sections, 'Title ID').toUpperCase();
+  const status = sectionValue(sections, 'Compatibility status').toLowerCase();
+  const testedVersion = sectionValue(
+    sections,
+    'SharpEmu build (commit or release, not the game version)',
+    'SharpEmu version (commit or release)',
+  );
+  let testedDate = sectionValue(sections, 'Test date');
+  const gameVersion = sectionValue(sections, 'Game version');
+  const os = sectionValue(sections, 'Operating system').toLowerCase();
+  const hardware = sectionValue(sections, 'Hardware (CPU / GPU)');
+  const notes = sanitizeIssueMarkdown(sectionValue(sections, 'What works / what breaks'));
+  const ownership = sectionValue(sections, 'Testing confirmation');
+
+  if (!/^PPSA\d{5}$/.test(titleId)) {
+    throw new Error(`Issue #${issue.number}: invalid Title ID "${titleId}".`);
+  }
+  if (!STATUSES.has(status)) {
+    throw new Error(`Issue #${issue.number}: invalid compatibility status "${status}".`);
+  }
+  if (!testedVersion) {
+    throw new Error(`Issue #${issue.number}: missing SharpEmu build.`);
+  }
+  if (!testedDate) {
+    testedDate = String(issue.createdAt ?? '').slice(0, 10);
+    warnings.push(`Test date was missing; using the issue creation date (${testedDate}).`);
+  }
+  if (!validDate(testedDate)) {
+    throw new Error(`Issue #${issue.number}: invalid test date "${testedDate}".`);
+  }
+  if (!OPERATING_SYSTEMS.has(os)) {
+    throw new Error(`Issue #${issue.number}: invalid operating system "${os}".`);
+  }
+  if (!notes) {
+    throw new Error(`Issue #${issue.number}: missing compatibility notes or evidence.`);
+  }
+  if (ownership && !/\[[xX]\]/.test(ownership)) {
+    throw new Error(`Issue #${issue.number}: testing ownership was not confirmed.`);
+  }
+  if (!ownership) {
+    warnings.push('Legacy issue has no ownership checkbox; maintainer approval is required.');
+  }
+
+  const game = games.find((candidate) =>
+    (candidate.allTitleIds ?? [candidate.titleId]).includes(titleId),
+  );
+  if (!game) {
+    throw new Error(`Issue #${issue.number}: Title ID ${titleId} is not in the game catalog.`);
+  }
+
+  return {
+    issue: {
+      number: issue.number,
+      url: issue.url,
+    },
+    game,
+    titleId,
+    status,
+    testedVersion,
+    testedDate,
+    gameVersion: gameVersion || undefined,
+    os,
+    hardware: hardware || undefined,
+    notes,
+    warnings,
+  };
+}
+
+export function chooseReportTarget(report, existingFileNames = []) {
+  const existingByUppercase = new Map(
+    existingFileNames.map((fileName) => [fileName.toUpperCase(), fileName]),
+  );
+  const aliases = report.game.allTitleIds ?? [report.game.titleId];
+
+  for (const titleId of aliases) {
+    const existing = existingByUppercase.get(`${titleId}.MD`);
+    if (existing) {
+      return {
+        fileName: existing,
+        titleId: path.basename(existing, path.extname(existing)).toUpperCase(),
+        updating: true,
+      };
+    }
+  }
+
+  return {
+    fileName: `${report.titleId}.md`,
+    titleId: report.titleId,
+    updating: false,
+  };
+}
+
+function yamlString(value) {
+  return JSON.stringify(String(value));
+}
+
+export function renderReport(report, targetTitleId = report.titleId) {
+  const frontmatter = [
+    '---',
+    `titleId: ${yamlString(targetTitleId)}`,
+    `status: ${yamlString(report.status)}`,
+    `testedVersion: ${yamlString(report.testedVersion)}`,
+    `testedDate: ${yamlString(report.testedDate)}`,
+    ...(report.gameVersion ? [`gameVersion: ${yamlString(report.gameVersion)}`] : []),
+    `os: ${yamlString(report.os)}`,
+    ...(report.hardware ? [`hardware: ${yamlString(report.hardware)}`] : []),
+    '---',
+  ];
+
+  return `${frontmatter.join('\n')}\n\n${report.notes}\n\n> Source: [GitHub compatibility report #${report.issue.number}](${report.issue.url})\n`;
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main() {
+  const issueNumber = Number(argument('--issue'));
+  const repository = argument('--repo') ?? process.env.GITHUB_REPOSITORY;
+  if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error('--issue must be a positive integer.');
+  }
+  if (!repository || !/^[^/]+\/[^/]+$/.test(repository)) {
+    throw new Error('--repo or GITHUB_REPOSITORY must be owner/name.');
+  }
+
+  const issue = JSON.parse(
+    execFileSync(
+      'gh',
+      [
+        'issue',
+        'view',
+        String(issueNumber),
+        '--repo',
+        repository,
+        '--json',
+        'number,title,body,url,createdAt,state',
+      ],
+      { encoding: 'utf8' },
+    ),
+  );
+  if (issue.state !== 'OPEN') {
+    throw new Error(`Issue #${issueNumber} is not open.`);
+  }
+
+  const root = process.cwd();
+  const games = JSON.parse(
+    await readFile(path.join(root, 'src/data/games.json'), 'utf8'),
+  );
+  const report = normalizeReport(issue, games);
+  const compatibilityDirectory = path.join(root, 'src/content/compat');
+  await mkdir(compatibilityDirectory, { recursive: true });
+  const existingFileNames = await readdir(compatibilityDirectory);
+  const target = chooseReportTarget(report, existingFileNames);
+  const reportPath = path.join(compatibilityDirectory, target.fileName);
+  await writeFile(reportPath, renderReport(report, target.titleId), 'utf8');
+
+  const relativePath = path.relative(root, reportPath).split(path.sep).join('/');
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `report_path=${relativePath}\nwarning_count=${report.warnings.length}\n`,
+    );
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const summary = [
+      `### Compatibility report #${issueNumber}`,
+      '',
+      `Generated \`${relativePath}\` for **${report.game.name}**.`,
+      '',
+      ...report.warnings.map((warning) => `- ⚠️ ${warning}`),
+      '',
+    ];
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, summary.join('\n'));
+  }
+
+  console.log(
+    `${target.updating ? 'Updated' : 'Created'} ${relativePath} from issue #${issueNumber}.`,
+  );
+  for (const warning of report.warnings) console.warn(`Warning: ${warning}`);
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/issue-to-compat.test.mjs
+++ b/scripts/issue-to-compat.test.mjs
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chooseReportTarget,
+  normalizeReport,
+  parseIssueForm,
+  renderReport,
+  sanitizeIssueMarkdown,
+} from './issue-to-compat.mjs';
+
+const games = [
+  {
+    name: "Demon's Souls",
+    titleId: 'PPSA01339',
+    allTitleIds: ['PPSA01339', 'PPSA01342'],
+  },
+];
+
+const currentIssue = {
+  number: 4,
+  url: 'https://github.com/sharpemu/sharpemu-site/issues/4',
+  createdAt: '2026-07-17T07:49:21Z',
+  body: `### Title ID
+
+PPSA01342
+
+### Compatibility status
+
+boots
+
+### SharpEmu version (commit or release)
+
+24b82a7
+
+### Operating system
+
+windows
+
+### Hardware (CPU / GPU)
+
+Ryzen 9 9950X3D / RTX 5090
+
+### What works / what breaks
+
+Boots after the splash screen.
+
+<img alt="Brightness screen" src="https://github.com/user-attachments/assets/example" />
+`,
+};
+
+describe('issue compatibility report converter', () => {
+  it('parses GitHub issue-form sections', () => {
+    const sections = parseIssueForm(currentIssue.body);
+
+    expect(sections.get('Title ID')).toBe('PPSA01342');
+    expect(sections.get('Compatibility status')).toBe('boots');
+  });
+
+  it('supports legacy issues and records inferred fields as warnings', () => {
+    const report = normalizeReport(currentIssue, games);
+
+    expect(report.testedDate).toBe('2026-07-17');
+    expect(report.titleId).toBe('PPSA01342');
+    expect(report.warnings).toHaveLength(2);
+  });
+
+  it('accepts the current issue form fields', () => {
+    const issue = {
+      ...currentIssue,
+      body: `### Title ID
+
+PPSA01342
+
+### Compatibility status
+
+boots
+
+### SharpEmu build (commit or release, not the game version)
+
+24b82a7
+
+### Test date
+
+2026-07-16
+
+### Game version
+
+1.004
+
+### Operating system
+
+windows
+
+### Hardware (CPU / GPU)
+
+Ryzen 9 9950X3D / RTX 5090
+
+### What works / what breaks
+
+Reaches the intro and then stops.
+
+### Testing confirmation
+
+- [X] I tested a dump of a game I own.
+`,
+    };
+
+    const report = normalizeReport(issue, games);
+
+    expect(report.testedDate).toBe('2026-07-16');
+    expect(report.gameVersion).toBe('1.004');
+    expect(report.os).toBe('windows');
+    expect(report.warnings).toEqual([]);
+  });
+
+  it('converts trusted GitHub attachment images and strips other HTML', () => {
+    const markdown = sanitizeIssueMarkdown(
+      '<img alt="Frame" src="https://github.com/user-attachments/assets/123" /><script>alert(1)</script>',
+    );
+
+    expect(markdown).toBe(
+      '![Frame](https://github.com/user-attachments/assets/123)alert(1)',
+    );
+    expect(markdown).not.toContain('<script>');
+  });
+
+  it('updates an existing regional report instead of creating a duplicate', () => {
+    const report = normalizeReport(currentIssue, games);
+
+    expect(chooseReportTarget(report, ['PPSA01339.md'])).toEqual({
+      fileName: 'PPSA01339.md',
+      titleId: 'PPSA01339',
+      updating: true,
+    });
+  });
+
+  it('renders validated frontmatter and a source backlink', () => {
+    const report = normalizeReport(currentIssue, games);
+    const markdown = renderReport(report);
+
+    expect(markdown).toContain('titleId: "PPSA01342"');
+    expect(markdown).toContain('testedVersion: "24b82a7"');
+    expect(markdown).toContain('testedDate: "2026-07-17"');
+    expect(markdown).toContain('GitHub compatibility report #4');
+  });
+
+  it('rejects title IDs that are not in the catalog', () => {
+    const issue = {
+      ...currentIssue,
+      body: currentIssue.body.replace('PPSA01342', 'PPSA99999'),
+    };
+
+    expect(() => normalizeReport(issue, games)).toThrow('is not in the game catalog');
+  });
+});

--- a/src/lib/compat.test.ts
+++ b/src/lib/compat.test.ts
@@ -6,6 +6,7 @@ const valid = {
   status: 'ingame',
   testedVersion: 'dev',
   testedDate: '2026-07-17',
+  gameVersion: '1.004',
   os: 'macos',
 };
 

--- a/src/lib/compat.ts
+++ b/src/lib/compat.ts
@@ -9,6 +9,7 @@ export const compatSchema = z.object({
   status: z.enum(STATUSES),
   testedVersion: z.string().min(1),
   testedDate: z.coerce.date(),
+  gameVersion: z.string().min(1).optional(),
   os: z.enum(['windows', 'linux', 'macos']),
   hardware: z.string().optional(),
   score: z.number().int().min(1).max(5).optional(),

--- a/src/pages/compatibility/report.astro
+++ b/src/pages/compatibility/report.astro
@@ -24,6 +24,7 @@ titleId: PPSA01284
 status: ingame        # nothing | boots | menus | ingame | playable
 testedVersion: dev    # SharpEmu release or commit
 testedDate: 2026-07-17
+gameVersion: "1.004"  # optional game update/version
 os: windows           # windows | linux | macos
 hardware: "RTX 4070, Ryzen 5 7600"
 score: 3              # optional 1-5 experience rating
@@ -36,6 +37,7 @@ put images next to the file and reference them relatively.</code></pre>
       <li>Test with dumps of games you own. Piracy reports are removed.</li>
       <li>One report per game — update the existing file if it's outdated.</li>
       <li>Note the exact SharpEmu build you tested.</li>
+      <li>Maintainers can add the <code>compat-approved</code> label to create a validated PR automatically.</li>
     </ul>
   </section>
 </Base>

--- a/src/pages/game/[titleId].astro
+++ b/src/pages/game/[titleId].astro
@@ -76,6 +76,7 @@ const fmt = (d: string | Date) =>
           <div class="mt-5 rounded-2xl border border-line bg-surface p-7">
             <p class="font-mono text-xs text-muted">
               Tested on SharpEmu <span class="font-semibold text-ink">{report.data.testedVersion}</span> ·{' '}
+              {report.data.gameVersion && `game ${report.data.gameVersion} · `}
               {report.data.os} · {fmt(report.data.testedDate)}
               {report.data.hardware && ` · ${report.data.hardware}`}
             </p>


### PR DESCRIPTION
## What changed

- extend the compatibility issue form with test date, optional game version, and ownership confirmation
- add a hardened issue-form converter that validates catalog IDs, sanitizes submitted Markdown, handles regional aliases, and preserves source permalinks
- add a maintainer-gated GitHub Actions workflow that opens draft report PRs when `compat-approved` is applied
- display optional game versions in published compatibility reports
- document activation and maintainer review steps

## Why

Compatibility submissions currently stop as issues and require maintainers to manually recreate their data as Markdown. The new flow keeps issues as intake records while automating the mechanical conversion into reviewable source changes. It never auto-merges or auto-approves a report.

## Repository setup already completed

The `compat-report`, `compat-approved`, and `compat-pr-opened` labels now exist, and all four existing compatibility issues carry the neutral `compat-report` intake label.

The SharpEmu organization currently blocks Actions-created PRs for the built-in `GITHUB_TOKEN`. Before report conversion can open PRs, an organization owner must enable that policy or a fine-grained `COMPAT_BOT_TOKEN` repository secret must be added as documented in the README.

## Validation

- `npm test` — 8 files, 52 tests passed
- `npm run build` — 8,716 pages built and Pagefind completed
- `actionlint .github/workflows/compat-report.yml`
- converter parsed issues #1, #2, #4, and #5 successfully without publishing them
