### PR TITLE
fix: constrain game cards to single column on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -154,7 +154,7 @@ const barSegments = STATUSES.filter((s) => stats.counts[s] > 0);
     {
       latest.length > 0 ? (
         <>
-          <div class="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+          <div class="mt-10 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
             {latest.map(({ game, entry }) => (
               <ReportCard game={game} entry={entry} />
             ))}


### PR DESCRIPTION
Add grid-cols-1 to the compatibility grid so ReportCard components no longer overflow their container on small screens.

Resolves sharpemu/sharpemu-site#28