### PR TITLE
A formatting fix and a minor rewording on the homepage

### DIFF
--- a/src/pages/compatibility/report.astro
+++ b/src/pages/compatibility/report.astro
@@ -9,7 +9,7 @@ import { SITE } from '../../config';
     <p>Two ways to contribute, easiest first:</p>
     <h2>1. Open an issue</h2>
     <p>
-      Use the
+      Use the{" "}
       <a href={`${SITE.siteRepoUrl}/issues/new?template=compatibility_report.yml`}>
         compatibility report template</a
       >. A maintainer will convert it into a report page.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,7 +68,7 @@ const barSegments = STATUSES.filter((s) => stats.counts[s] > 0);
             for="home-q"
             class="font-mono text-[11px] font-medium tracking-[0.22em] text-muted uppercase"
           >
-            Does your game run?
+            Does your favourite game run?
           </label>
           <div class="relative mt-3">
             <input


### PR DESCRIPTION
This PR makes two small changes: a formatting fix in the compatibility report page and a minor copy tweak on the homepage

`report.astro` 
<img width="692" height="140" alt="image" src="https://github.com/user-attachments/assets/96b8a103-74c0-4cf9-b3e5-b1398b396a6d" />
Changed to ↓
<img width="745" height="154" alt="image" src="https://github.com/user-attachments/assets/59a9f480-f74a-4a46-81cf-094f07d1bd98" />

`index.astro`
<img width="674" height="155" alt="image" src="https://github.com/user-attachments/assets/50925287-5489-44c9-82dd-55069fb85860" />
Changed to ↓
<img width="733" height="213" alt="image" src="https://github.com/user-attachments/assets/b82dfb5f-465f-4cd7-a1b4-733386dfae05" />
