### PR TITLE
compat: import report #32

### DIFF
--- a/src/content/compat/PPSA02929.md
+++ b/src/content/compat/PPSA02929.md
@@ -1,0 +1,21 @@
+---
+titleId: "PPSA02929"
+status: "playable"
+testedVersion: "90c72eb"
+testedDate: "2026-07-19"
+gameVersion: "1.000.000"
+os: "windows"
+hardware: "AMD Radeon Pro 5500M / Intel i9-9980HK"
+---
+
+Game boots, loads, and is playable.
+
+[PPSA02929.log](https://github.com/user-attachments/files/30170719/PPSA02929.log)
+
+![Image](https://github.com/user-attachments/assets/bdc56c53-a2d9-4e53-b518-16a723a7f3b0)
+
+![Image](https://github.com/user-attachments/assets/ff32bac1-0024-41ef-8f6b-da444a8e5a64)
+
+![Image](https://github.com/user-attachments/assets/11732b95-aa61-4b77-a6c9-47a10285fac2)
+
+> Source: [GitHub compatibility report #32](https://github.com/sharpemu/sharpemu-site/issues/32)


### PR DESCRIPTION
Generated from compatibility report #32 after maintainer approval.

Please review the inferred metadata and submitted evidence before merging.

Closes #32