### PR TITLE
Allow comments to be disabled per game

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ npm run preview    # serve dist/
 
 ## Games database
 
-`src/data/games.json` is generated — do not edit by hand.
+`src/data/games.json` is generated — do not edit imported game metadata by hand.
+The supported exception is the optional `"commentsDisabled": true` per-game
+override; imports preserve this setting across database refreshes.
 
 ```bash
 npm run import                          # refresh title list (no enrichment)
@@ -26,6 +28,10 @@ npm run import -- --enrich 300          # + enrich 300 concepts with covers/meta
 npm run import -- --only PPSA01284      # enrich specific title IDs (comma-separated)
 npm run import -- --force               # accept a >5% shrink of the list
 ```
+
+To hide the comments section for a game, add `"commentsDisabled": true` to its
+entry in `src/data/games.json`. Omitting the property (or setting it to `false`)
+keeps comments enabled.
 
 Sources: [andshrew/PlayStation-Titles](https://github.com/andshrew/PlayStation-Titles)
 (MIT, title IDs/names/regions) + the public PlayStation Store GraphQL endpoint
@@ -49,6 +55,11 @@ A report may use any regional title ID (e.g. `PPSA10112`); the site resolves
 it to the game's primary entry automatically. The build fails on reports whose
 title ID isn't in the database or whose filename doesn't match the front
 matter.
+
+To disable comments from an authored compatibility report, add
+`commentsDisabled: true` to its frontmatter. Either this report setting or the
+game database override hides the comments section. Automated issue conversion
+preserves the manual report setting when updating an existing report.
 
 ### Maintainer report conversion
 

--- a/scripts/issue-to-compat.mjs
+++ b/scripts/issue-to-compat.mjs
@@ -176,7 +176,14 @@ function yamlString(value) {
   return JSON.stringify(String(value));
 }
 
-export function renderReport(report, targetTitleId = report.titleId) {
+export function manualReportOptions(markdown) {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(String(markdown))?.[1] ?? '';
+  return {
+    commentsDisabled: /^commentsDisabled:[ \t]*true[ \t]*(?:#.*)?$/m.test(frontmatter),
+  };
+}
+
+export function renderReport(report, targetTitleId = report.titleId, options = {}) {
   const frontmatter = [
     '---',
     `titleId: ${yamlString(targetTitleId)}`,
@@ -186,6 +193,7 @@ export function renderReport(report, targetTitleId = report.titleId) {
     ...(report.gameVersion ? [`gameVersion: ${yamlString(report.gameVersion)}`] : []),
     `os: ${yamlString(report.os)}`,
     ...(report.hardware ? [`hardware: ${yamlString(report.hardware)}`] : []),
+    ...(options.commentsDisabled ? ['commentsDisabled: true'] : []),
     '---',
   ];
 
@@ -236,7 +244,10 @@ async function main() {
   const existingFileNames = await readdir(compatibilityDirectory);
   const target = chooseReportTarget(report, existingFileNames);
   const reportPath = path.join(compatibilityDirectory, target.fileName);
-  await writeFile(reportPath, renderReport(report, target.titleId), 'utf8');
+  const manualOptions = target.updating
+    ? manualReportOptions(await readFile(reportPath, 'utf8'))
+    : {};
+  await writeFile(reportPath, renderReport(report, target.titleId, manualOptions), 'utf8');
 
   const relativePath = path.relative(root, reportPath).split(path.sep).join('/');
   if (process.env.GITHUB_OUTPUT) {

--- a/scripts/issue-to-compat.test.mjs
+++ b/scripts/issue-to-compat.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   chooseReportTarget,
+  manualReportOptions,
   normalizeReport,
   parseIssueForm,
   renderReport,
@@ -141,6 +142,18 @@ Reaches the intro and then stops.
     expect(markdown).toContain('testedVersion: "24b82a7"');
     expect(markdown).toContain('testedDate: "2026-07-17"');
     expect(markdown).toContain('GitHub compatibility report #4');
+  });
+
+  it('preserves a manually disabled comments setting when updating a report', () => {
+    const report = normalizeReport(currentIssue, games);
+    const existing = `---
+titleId: "PPSA01342"
+commentsDisabled: true
+---
+`;
+    const markdown = renderReport(report, report.titleId, manualReportOptions(existing));
+
+    expect(markdown).toContain('commentsDisabled: true');
   });
 
   it('rejects title IDs that are not in the catalog', () => {

--- a/scripts/lib/transform.mjs
+++ b/scripts/lib/transform.mjs
@@ -42,8 +42,13 @@ export function mergeExisting(fresh, existing) {
   const prev = new Map(existing.map((g) => [g.conceptId, g]));
   return fresh.map((g) => {
     const old = prev.get(g.conceptId);
-    if (!old?.enriched) return g;
+    if (!old) return g;
+    const withOverrides =
+      old.commentsDisabled === undefined
+        ? g
+        : { ...g, commentsDisabled: old.commentsDisabled };
+    if (!old.enriched) return withOverrides;
     const { name, cover, publisher, releaseDate, genres, enriched, noStore } = old;
-    return { ...g, name, cover, publisher, releaseDate, genres, enriched, noStore };
+    return { ...withOverrides, name, cover, publisher, releaseDate, genres, enriched, noStore };
   });
 }

--- a/scripts/lib/transform.test.mjs
+++ b/scripts/lib/transform.test.mjs
@@ -51,4 +51,8 @@ describe('mergeExisting', () => {
     const merged = mergeExisting(fresh, [{ ...fresh[0] }]);
     expect(merged[0].enriched).toBeUndefined();
   });
+  it('preserves per-game comment overrides independently of enrichment', () => {
+    const merged = mergeExisting(fresh, [{ ...fresh[0], commentsDisabled: true }]);
+    expect(merged[0].commentsDisabled).toBe(true);
+  });
 });

--- a/src/lib/compat.test.ts
+++ b/src/lib/compat.test.ts
@@ -21,6 +21,10 @@ describe('compatSchema', () => {
     expect(() => compatSchema.parse({ ...valid, titleId: 'CUSA00001' })).toThrow());
   it('rejects score out of range', () =>
     expect(() => compatSchema.parse({ ...valid, score: 6 })).toThrow());
+  it('accepts a manual comments override', () => {
+    const r = compatSchema.parse({ ...valid, commentsDisabled: true });
+    expect(r.commentsDisabled).toBe(true);
+  });
 });
 
 describe('computeStats', () => {

--- a/src/lib/compat.ts
+++ b/src/lib/compat.ts
@@ -13,6 +13,7 @@ export const compatSchema = z.object({
   os: z.enum(['windows', 'linux', 'macos']),
   hardware: z.string().optional(),
   score: z.number().int().min(1).max(5).optional(),
+  commentsDisabled: z.boolean().optional(),
 });
 
 // badgeClass and barColor both resolve through CSS custom properties defined in

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -12,6 +12,7 @@ export type Game = {
   genres?: string[];
   enriched?: boolean;
   noStore?: boolean;
+  commentsDisabled?: boolean;
 };
 
 export const games = gamesJson as Game[];

--- a/src/pages/game/[titleId].astro
+++ b/src/pages/game/[titleId].astro
@@ -99,9 +99,15 @@ const fmt = (d: string | Date) =>
       }
     </section>
 
-    <section class="mt-16 pb-4" data-pagefind-ignore>
-      <h2 class="font-display text-2xl font-bold tracking-tight">Comments</h2>
-      <div class="mt-5"><Giscus term={game.titleId} /></div>
-    </section>
+    {
+      !game.commentsDisabled && !report?.data.commentsDisabled && (
+        <section class="mt-16 pb-4" data-pagefind-ignore>
+          <h2 class="font-display text-2xl font-bold tracking-tight">Comments</h2>
+          <div class="mt-5">
+            <Giscus term={game.titleId} />
+          </div>
+        </section>
+      )
+    }
   </article>
 </Base>


### PR DESCRIPTION
## What changed

- add an optional `commentsDisabled` override to game records
- allow compatibility reports to disable comments through frontmatter
- omit the complete comments section when either override is enabled
- preserve game overrides during catalog imports
- preserve report overrides when the issue converter updates an existing report
- document both manual configuration paths

## Why

Some game pages need discussion disabled without turning off giscus site-wide. Maintainers can now control that behavior from either the generated game catalog or an authored compatibility report.

## Validation

- `npm test` — 56 tests passed
- `npm run build` — 8,740 pages built successfully
- `git diff --check`
