### PR TITLE
compat: publish 16 audited reports

### DIFF
--- a/src/content/compat/PPSA01417.md
+++ b/src/content/compat/PPSA01417.md
@@ -1,0 +1,23 @@
+---
+titleId: "PPSA01417"
+status: "boots"
+testedVersion: "498d402"
+testedDate: "2026-08-10"
+gameVersion: "01.015.001"
+os: "windows"
+hardware: "CPU: AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM: 20GB; RAM: 259.736 MB (253,6 GB)"
+---
+
+The game boots and loads `eboot.bin` successfully.
+
+Three modules are loaded successfully:
+- libc.prx
+- libSceJobManager.prx
+- libSceNpCppWebApi.prx
+
+Module preload reports `loaded=3, failed=0`. Imported data rebind reports `unresolved=0`.
+Module initializers complete normally with `Guest returned: 0` and `Execute END (LastError: null)`.
+
+After the main entry point starts, unresolved import warnings appear.
+
+> Source: [GitHub compatibility report #91](https://github.com/sharpemu/sharpemu-site/issues/91)

--- a/src/content/compat/PPSA01603.md
+++ b/src/content/compat/PPSA01603.md
@@ -1,0 +1,25 @@
+---
+titleId: "PPSA01603"
+status: "boots"
+testedVersion: "62c3852"
+testedDate: "2026-08-09"
+gameVersion: "01.000.013"
+os: "windows"
+hardware: "AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM:20GB; RAM: 259.736 MB (253,6 GB)"
+---
+
+Behavior
+The game boots and loads eboot.bin successfully.
+Five modules are loaded successfully and module preload reports loaded=5, failed=0. Imported data rebind reports unresolved=0.
+
+Several module initializers return normally with Guest returned: 0.
+
+During early startup, several imports return ORBIS_GEN2_ERROR_TRY_AGAIN while platform memory is being reserved.
+
+PS5PlatformMemory: Reserved=104857600
+21
+Import#26 result: ORBIS_GEN2_ERROR_TRY_AGAIN
+Import#27 result: ORBIS_GEN2_ERROR_TRY_AGAIN
+Import#44 result: ORBIS_GEN2_ERROR_TRY_AGAIN
+
+> Source: [GitHub compatibility report #85](https://github.com/sharpemu/sharpemu-site/issues/85)

--- a/src/content/compat/PPSA01670.md
+++ b/src/content/compat/PPSA01670.md
@@ -1,0 +1,22 @@
+---
+titleId: "PPSA01670"
+status: "boots"
+testedVersion: "498d402"
+testedDate: "2026-08-09"
+gameVersion: "01.405.000"
+os: "windows"
+hardware: "AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM: 20GB; RAM: 259.736 MB (253,6 GB)"
+---
+
+GPU: The first logo is showing but no more! CPU side: The game boots successfully and all modules initialize correctly, but later stalls and never progresses.
+
+The game boots and loads `eboot.bin` successfully.
+The game gets further than a simple boot failure: Vulkan initializes, a window is created, a DualSense controller is detected, and a first frame is presented.
+
+After startup, the game schedules multiple guest threads, including load tasks, worker threads, savegame, StreamControl, arkAsyncResourceLoader, online service, and audio threads.
+
+The log then shows repeated unresolved import warnings and repeated import failures.
+
+![Image](https://github.com/user-attachments/assets/0aff7291-a638-4342-97f5-654104ce896a)
+
+> Source: [GitHub compatibility report #84](https://github.com/sharpemu/sharpemu-site/issues/84)

--- a/src/content/compat/PPSA01968.md
+++ b/src/content/compat/PPSA01968.md
@@ -1,0 +1,24 @@
+---
+titleId: "PPSA01968"
+status: "boots"
+testedVersion: "62c3852"
+testedDate: "2026-08-09"
+gameVersion: "01.000.000"
+os: "windows"
+hardware: "CPU: AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM: 20GB; RAM: 259.736 MB (253,6 GB)."
+---
+
+Game Boots
+Shows Noting
+
+Import#17 unresolved: nid=wkQR9+xTFKY
+Import#19 unresolved: nid=Q07J7XpvhrU
+Import#21 unresolved: nid=EDq5bqCqYpA
+
+ORBIS_GEN2_ERROR_NOT_FOUND
+(1-efe3d3)
+
+Fatal error occurred:
+VirtualMemory::Allocated called without an address in commit mode
+
+> Source: [GitHub compatibility report #87](https://github.com/sharpemu/sharpemu-site/issues/87)

--- a/src/content/compat/PPSA02199.md
+++ b/src/content/compat/PPSA02199.md
@@ -1,0 +1,15 @@
+---
+titleId: "PPSA02199"
+status: "boots"
+testedVersion: "418eb7e with v0.0.3 release-2"
+testedDate: "2026-08-05"
+gameVersion: "v01.003.000"
+os: "macos"
+hardware: "MacBook 10,1"
+---
+
+Works: Game is read properly, but boots to black screen. Music is still played in Background
+
+Breaks: No Image is shown
+
+> Source: [GitHub compatibility report #81](https://github.com/sharpemu/sharpemu-site/issues/81)

--- a/src/content/compat/PPSA02494.md
+++ b/src/content/compat/PPSA02494.md
@@ -1,0 +1,16 @@
+---
+titleId: "PPSA02494"
+status: "boots"
+testedVersion: "62c3852"
+testedDate: "2026-08-09"
+gameVersion: "01.000.000"
+os: "windows"
+hardware: "CPU: AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM: 20GB; RAM: 259.736 MB (253,6 GB)."
+---
+
+Game Boots
+Nothing happens
+
+The game boots and loads successfully at first. The executable and required modules are loaded, imports are mostly resolved, and several module initializers return successfully. However, after startup the game stops making progress and appears to freeze. The execution is stuck while waiting in libKernel:pthread_cond_wait.
+
+> Source: [GitHub compatibility report #86](https://github.com/sharpemu/sharpemu-site/issues/86)

--- a/src/content/compat/PPSA04719.md
+++ b/src/content/compat/PPSA04719.md
@@ -1,0 +1,20 @@
+---
+titleId: "PPSA04719"
+status: "nothing"
+testedVersion: "62c3852"
+testedDate: "2026-08-09"
+gameVersion: "01.700.000"
+os: "windows"
+hardware: "CPU: AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM: 20GB; RAM: 259.736 MB (253,6 GB)."
+---
+
+Game Tryes to boot but fails because of missing Modules
+
+Import#17930 unresolved: nid=wse4gunZeJU
+Import#17931 unresolved: nid=B5o-N7kNTxs
+Import#17932 unresolved: nid=B5o-N7kNTxs
+Import#18141 unresolved: nid=GvGvswb0v34
+Import#18142 unresolved: nid=W72B9ylU2JA
+First party modules need to be loaded before configureSDK.
+
+> Source: [GitHub compatibility report #89](https://github.com/sharpemu/sharpemu-site/issues/89)

--- a/src/content/compat/PPSA04795.md
+++ b/src/content/compat/PPSA04795.md
@@ -1,0 +1,13 @@
+---
+titleId: "PPSA04795"
+status: "boots"
+testedVersion: "498d402"
+testedDate: "2026-08-10"
+gameVersion: "01.000.002"
+os: "windows"
+hardware: "CPU: AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM:20GB, RAM: 259.736 MB (253,6 GB)"
+---
+
+KLONOA boots successfully through the loader phase: the eboot.bin loads, 10 modules preload successfully, imported data rebind has no unresolved entries, and module initializers return normally. The game then reaches main entry execution, prints input/control information, schedules a guest thread, and stalls repeatedly in libKernel:pthread_cond_wait.
+
+> Source: [GitHub compatibility report #90](https://github.com/sharpemu/sharpemu-site/issues/90)

--- a/src/content/compat/PPSA05510.md
+++ b/src/content/compat/PPSA05510.md
@@ -1,0 +1,13 @@
+---
+titleId: "PPSA05510"
+status: "nothing"
+testedVersion: "v0.0.3"
+testedDate: "2026-08-04"
+gameVersion: "v01.013.000"
+os: "windows"
+hardware: "Intel Core I5-10400F / NVIDIA RTX 3050 / RAM 16GB DDR4"
+---
+
+[console.txt](https://github.com/user-attachments/files/30704983/console.txt)
+
+> Source: [GitHub compatibility report #78](https://github.com/sharpemu/sharpemu-site/issues/78)

--- a/src/content/compat/PPSA08448.md
+++ b/src/content/compat/PPSA08448.md
@@ -1,0 +1,17 @@
+---
+titleId: "PPSA08448"
+status: "boots"
+testedVersion: "41ec56f"
+testedDate: "2026-07-17"
+gameVersion: "01.000.000"
+os: "windows"
+hardware: "7600x / RTX 4070 S"
+---
+
+**BOOT FOR 10 SEC and after that ,  Crash**
+
+![Image](https://github.com/user-attachments/assets/5b5e2352-1287-4389-a672-d00bd5a5c4ee)
+
+[SharpEmuLog-PPSA08448-20260717-144436.txt](https://github.com/user-attachments/files/30123218/SharpEmuLog-PPSA08448-20260717-144436.txt)
+
+> Source: [GitHub compatibility report #8](https://github.com/sharpemu/sharpemu-site/issues/8)

--- a/src/content/compat/PPSA15246.md
+++ b/src/content/compat/PPSA15246.md
@@ -1,0 +1,22 @@
+---
+titleId: "PPSA15246"
+status: "nothing"
+testedVersion: "da0de5c"
+testedDate: "2026-08-07"
+gameVersion: "01.006"
+os: "windows"
+hardware: "AMD Ryzen 7 5700X / NVIDIA GeForce RTX 5060"
+---
+
+The game boots and loads eboot.bin and the libc.prx module, sets up all import stubs
+(893/893), and starts 12 guest threads. Two imports remain unresolved
+(nid=5ikmEzL7Xng and nid=B3KyDf-Zjh0). Execution then completely stalls for 20s
+with no progress, with most threads blocked on sceKernelWaitSema /
+sceKernelWaitEventFlag. The process exits with code 4 (emulation error)
+
+Also tested with SHARPEMU_DISABLE_IMPORT_LOOP_GUARD enabled: no change, same
+blocking NID, same crash
+
+Nothing is displayed on screen (crashes before any image/menu)
+
+> Source: [GitHub compatibility report #82](https://github.com/sharpemu/sharpemu-site/issues/82)

--- a/src/content/compat/PPSA15552.md
+++ b/src/content/compat/PPSA15552.md
@@ -1,0 +1,17 @@
+---
+titleId: "PPSA15552"
+status: "menus"
+testedVersion: "v0.0.3"
+testedDate: "2026-08-11"
+gameVersion: "01.000.000"
+os: "windows"
+hardware: "Ryzen 5 5600 / RTX 5070"
+---
+
+Main menu works at around 47fps, there's no audio whatsoever, settings tab in the game runs at 3fps.
+Once hitting play, the game runs constantly at 3fps trying to render the first cinematic.
+
+Main Menu
+![Image](https://github.com/user-attachments/assets/be01f4e9-dcb2-41e6-aad3-74341aabcb68)
+
+> Source: [GitHub compatibility report #93](https://github.com/sharpemu/sharpemu-site/issues/93)

--- a/src/content/compat/PPSA16441.md
+++ b/src/content/compat/PPSA16441.md
@@ -1,0 +1,13 @@
+---
+titleId: "PPSA16441"
+status: "boots"
+testedVersion: "da0de5c"
+testedDate: "2026-08-10"
+gameVersion: "1.000.000"
+os: "windows"
+hardware: "AMD Ryzen 7 9800x3d, Radeon RX 9070xt and 64gb of ram"
+---
+
+The game tries to boot and log says Forcing call to sce::Agc::suspendPoint to avoid TRC R5089 breach and will loop this message and not proceed any further.
+
+> Source: [GitHub compatibility report #92](https://github.com/sharpemu/sharpemu-site/issues/92)

--- a/src/content/compat/PPSA19015.md
+++ b/src/content/compat/PPSA19015.md
@@ -1,0 +1,16 @@
+---
+titleId: "PPSA19015"
+status: "boots"
+testedVersion: "62c3852"
+testedDate: "2026-08-09"
+gameVersion: "01.003.000"
+os: "windows"
+hardware: "CPU: AMD Ryzen 9 9950X3D; GPU: AMD Radeon RX 7900 XT; VRAM: 20GB; RAM: 259.736 MB (253,6 GB)."
+---
+
+Game Boots
+Stalls during initialization
+
+The game boots and initializes correctly but becomes permanently stalled due to blocked threads waiting on sceKernelWaitSema. SharpEmu subsequently detects a 20-second execution stall and exits with Emulation Error (Code 4)
+
+> Source: [GitHub compatibility report #88](https://github.com/sharpemu/sharpemu-site/issues/88)

--- a/src/content/compat/PPSA19563.md
+++ b/src/content/compat/PPSA19563.md
@@ -1,0 +1,19 @@
+---
+titleId: "PPSA19563"
+status: "boots"
+testedVersion: "41ec56f"
+testedDate: "2026-07-17"
+gameVersion: "v01.000"
+os: "windows"
+hardware: "7600x / RTX 4070 S"
+---
+
+BOOTS FOR 10 SEC and after that it crashes
+
+it used to do only splash screen in the older builds
+
+![Image](https://github.com/user-attachments/assets/aeaea6de-7d38-42a9-ab0d-1618e15f037c)
+
+[SharpEmuLog-PPSA19563-20260717-134206.txt](https://github.com/user-attachments/files/30121222/SharpEmuLog-PPSA19563-20260717-134206.txt)
+
+> Source: [GitHub compatibility report #7](https://github.com/sharpemu/sharpemu-site/issues/7)

--- a/src/content/compat/PPSA23226.md
+++ b/src/content/compat/PPSA23226.md
@@ -1,0 +1,16 @@
+---
+titleId: "PPSA23226"
+status: "nothing"
+testedVersion: "0b83b34"
+testedDate: "2026-07-20"
+gameVersion: "V01.021"
+os: "windows"
+hardware: "RX6600 XT Ryzen 5600"
+---
+
+It keeps showing black screen for about 5 min and it closes
+
+![Image](https://github.com/user-attachments/assets/2e9e7283-0f4a-45e2-b4a8-9efbfa536b17)
+![Image](https://github.com/user-attachments/assets/ab9d0487-95be-45e7-a086-e4832c075ccd)
+
+> Source: [GitHub compatibility report #34](https://github.com/sharpemu/sharpemu-site/issues/34)


### PR DESCRIPTION
## What changed

- Publishes 16 compatibility reports generated from the repository issue converter.
- Restores four valid reports that had been closed after their original conversions failed.
- Corrects unambiguous dates, the Death Stranding commit typo, the Miles Morales issue title, and Dead Cells status (`menus`).
- Preserves each issue as the source of submitted notes and evidence.

## Why

The reports pass the converter and catalog validation, but the configured compatibility workflow token could not push branches. This PR publishes the already-validated output through the maintainer SSH path.

## Validation

- `npm test` — 47/47 passed
- `npm run build` — 8,852 pages built; Pagefind completed
- `git diff --check`
- All 16 source issues pass `normalizeReport` and target new `.md` files

Closes #7
Closes #8
Closes #34
Closes #78
Closes #81
Closes #82
Closes #84
Closes #85
Closes #86
Closes #87
Closes #88
Closes #89
Closes #90
Closes #91
Closes #92
Closes #93
