### PR TITLE
Fix compatibility bot token routing

### DIFF
--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -30,7 +30,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.COMPAT_BOT_TOKEN || github.token }}
+      GH_TOKEN: ${{ github.token }}
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
       BRANCH: compat/issue-${{ github.event.issue.number || inputs.issue_number }}
 
@@ -39,7 +39,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.COMPAT_BOT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -95,6 +95,7 @@ jobs:
         if: steps.preflight.outputs.existing_url == ''
         shell: bash
         env:
+          PR_TOKEN: ${{ secrets.COMPAT_BOT_TOKEN || github.token }}
           REPORT_PATH: ${{ steps.convert.outputs.report_path }}
         run: |
           git config user.name "sharpemu-compat-bot"
@@ -118,7 +119,7 @@ jobs:
               "$ISSUE_NUMBER"
           )"
           pr_url="$(
-            gh pr create \
+            GH_TOKEN="$PR_TOKEN" gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head "$BRANCH" \

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ creating pull requests. To activate conversion, either:
 - Have an organization owner enable **Allow GitHub Actions to create and approve
   pull requests**; or
 - Add a fine-grained token as the `COMPAT_BOT_TOKEN` Actions secret, limited to
-  this repository with read/write access to Contents, Issues, and Pull requests.
+  this repository with read/write access to Pull requests.
 
-The workflow prefers `COMPAT_BOT_TOKEN` when present and otherwise uses
-`GITHUB_TOKEN`, so no workflow change is needed if the organization policy is
-enabled later.
+The workflow always uses `GITHUB_TOKEN` for checkout, branch pushes, comments,
+and labels. It uses `COMPAT_BOT_TOKEN` only to create the pull request, falling
+back to `GITHUB_TOKEN` when the organization policy allows that operation.
 
 ## Downloads page
 


### PR DESCRIPTION
## What changed

- Uses the built-in `GITHUB_TOKEN` for checkout, generated branch pushes, issue comments, and labels.
- Uses `COMPAT_BOT_TOKEN` only for PR creation, where organization policy requires a non-Actions token.
- Documents the narrower fine-grained token permission requirement.

## Root cause

All 16 validated conversion runs failed because the personal compatibility token was also used as the checkout credential. It could not push repository contents or add issue comments, even though the built-in workflow token already has those declared permissions.

## Validation

- `actionlint .github/workflows/compat-report.yml`
- `npm test` — 47/47 passed
- `git diff --check`
